### PR TITLE
chore(deps): update tool versions in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,13 +1,13 @@
-awscli 2.24.5 #https://github.com/MetricMike/asdf-awscli.git
-golang 1.23.6
-golang 1.24.0
-golangci-lint 1.64.5
-helm 3.17.1 #https://github.com/Antiarchitect/asdf-helm.git
+awscli 2.26.7 #https://github.com/MetricMike/asdf-awscli.git
+golang 1.23.8
+golang 1.24.2
+golangci-lint 1.64.8
+helm 3.17.3 #https://github.com/Antiarchitect/asdf-helm.git
 jq 1.7.1
-kubectl 1.32.2
+kubectl 1.32.3
 pre-commit 4.1.0
-python 3.11.11
-python 3.12.9
-python 3.13.2
-terraform 1.10.5
-terragrunt 0.73.5
+python 3.11.12
+python 3.12.10
+python 3.13.3
+terraform 1.11.4
+terragrunt 0.77.22


### PR DESCRIPTION
Bumps various tools to their latest versions:
- awscli from 2.24.5 to 2.26.7
- golang from 1.23.6 to 1.23.8 and 1.24.0 to 1.24.2
- golangci-lint from 1.64.5 to 1.64.8
- helm from 3.17.1 to 3.17.3
- kubectl from 1.32.2 to 1.32.3
- python from 3.11.11 to 3.11.12, 3.12.9 to 3.12.10, and 3.13.2 to 3.13.3
- terraform from 1.10.5 to 1.11.4
- terragrunt from 0.73.5 to 0.77.2