### PR TITLE
fix(release): stabilize tag publish workflow and release config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,6 +21,12 @@ categories:
 # Template for each change entry
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 
+# Template for the generated release notes body (required by release-drafter v6)
+template: |
+  ## What's Changed
+
+  $CHANGES
+
 # Fallback text for release notes if no changes are detected.
 no-changes-template: 'No notable changes.'
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,4 +31,4 @@ template: |
 no-changes-template: 'No notable changes.'
 
 # Optionally, mark the draft as a prerelease
-prerelease: false 
+prerelease: false

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -44,7 +44,7 @@ jobs:
           fi
 
           if gh release view "${tag}" >/dev/null 2>&1; then
-            gh release edit "${tag}" "${prerelease_args[@]}"
+            gh release edit "${tag}" --draft=false "${prerelease_args[@]}"
           else
             gh release create "${tag}" --verify-tag --generate-notes "${prerelease_args[@]}"
           fi

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -25,9 +25,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish GitHub Release for tag
-        uses: release-drafter/release-drafter@67e173cadb2fbd3de94f4a861e0c48c913b462ae # v6.4.0
-        with:
-          publish: true
-          tag: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+
+          # Treat semver pre-release tags (for example v1.2.3-rc.1) as prereleases.
+          prerelease_args=()
+          if [[ "${tag}" == *-* ]]; then
+            prerelease_args+=(--prerelease --latest=false)
+          else
+            prerelease_args+=(--latest)
+          fi
+
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            gh release edit "${tag}" "${prerelease_args[@]}"
+          else
+            gh release create "${tag}" --verify-tag --generate-notes "${prerelease_args[@]}"
+          fi

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -24,6 +24,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
       - name: Publish GitHub Release for tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add required template to .github/release-drafter.yml for release-drafter v6 compatibility
- switch tag publish path in Draft Release workflow to gh release create/edit for idempotent tag publishing
- add checkout in tag publish job so --verify-tag works

## Validation
- exercised release workflow using pre-release tags
- verified full pass on v2.2.2-rc.3:
  - Draft Release
  - Docker
  - Container Tests
  - Security Gate

## Notes
- v2.2.2-rc.1 and v2.2.2-rc.2 were failed test tags during workflow hardening